### PR TITLE
Conversation transition into Chat 

### DIFF
--- a/app/src/main/java/com/courseproject/tindar/ui/conversationlist/ConversationListFragment.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/conversationlist/ConversationListFragment.java
@@ -1,18 +1,18 @@
 package com.courseproject.tindar.ui.conversationlist;
 
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
-
-import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.GridLayoutManager;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import com.courseproject.tindar.R;
+import com.courseproject.tindar.ui.chat.ChatActivity;
 import com.courseproject.tindar.usecases.conversationlist.ConversationResponseModel;
 
 import java.util.ArrayList;
@@ -61,16 +61,42 @@ public class ConversationListFragment extends Fragment {
         convos.add(new ConversationResponseModel("lisbeth", "how do you do", "20:20"));
         convos.add(new ConversationResponseModel("mikael", "silence", "20:50"));
         // Set the adapter
-        if (view instanceof RecyclerView) {
+
+        RecyclerView recyclerView = view.findViewById(R.id.list);
+        if (recyclerView != null) {
             Context context = view.getContext();
-            RecyclerView recyclerView = (RecyclerView) view;
-            if (mColumnCount <= 1) {
-                recyclerView.setLayoutManager(new LinearLayoutManager(context));
-            } else {
-                recyclerView.setLayoutManager(new GridLayoutManager(context, mColumnCount));
-            }
-            recyclerView.setAdapter(new MyConversationRecyclerViewAdapter(convos));
+            recyclerView.setLayoutManager(new LinearLayoutManager(context));
+
+            MyConversationRecyclerViewAdapter adapter = new MyConversationRecyclerViewAdapter(convos);
+            recyclerView.setAdapter(adapter);
+
+            // Set click listener for conversation items
+            adapter.setOnItemClickListener(new MyConversationRecyclerViewAdapter.OnItemClickListener() {
+                @Override
+                public void onItemClick(ConversationResponseModel conversation) {
+                    // Handle the click here, navigate to ChatActivity
+                    Intent intent = new Intent(requireActivity(), ChatActivity.class);
+                    intent.putExtra("conversation_partner_name", conversation.getUserName());
+                    // Pass any other necessary data
+                    startActivity(intent);
+                }
+            });
         }
+
         return view;
-    }
-}
+    }   }
+//        RecyclerView recyclerView = null;
+//        if (view instanceof RecyclerView) {
+//            Context context = view.getContext();
+//            recyclerView = (RecyclerView) view;
+//            if (mColumnCount <= 1) {
+//                recyclerView.setLayoutManager(new LinearLayoutManager(context));
+//            } else {
+//                recyclerView.setLayoutManager(new GridLayoutManager(context, mColumnCount));
+//            }
+//            recyclerView.setAdapter(new MyConversationRecyclerViewAdapter(convos));
+//        }
+//
+//
+//        return view;
+//    }

--- a/app/src/main/java/com/courseproject/tindar/ui/conversationlist/MyConversationRecyclerViewAdapter.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/conversationlist/MyConversationRecyclerViewAdapter.java
@@ -1,6 +1,7 @@
 package com.courseproject.tindar.ui.conversationlist;
 
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
@@ -19,6 +20,15 @@ public class MyConversationRecyclerViewAdapter extends RecyclerView.Adapter<MyCo
 
     private final List<ConversationResponseModel> mValues;
 
+    public interface OnItemClickListener {
+        void onItemClick(ConversationResponseModel conversation);
+    }
+
+    private OnItemClickListener mListener;
+
+    public void setOnItemClickListener(OnItemClickListener listener) {
+        mListener = listener;
+    }
     public MyConversationRecyclerViewAdapter(List<ConversationResponseModel> items) {
         mValues = items;
     }
@@ -32,11 +42,21 @@ public class MyConversationRecyclerViewAdapter extends RecyclerView.Adapter<MyCo
 
     @Override
     public void onBindViewHolder(final ViewHolder holder, int position) {
+        final ConversationResponseModel conversation = mValues.get(position);
+
         holder.mItem = mValues.get(position);
         holder.mUserName.setText(mValues.get(position).getUserName());
         holder.mLastMessage.setText(mValues.get(position).getLastMessage());
         holder.mLastMessageTime.setText(mValues.get(position).getLastMessageTime());
-        
+
+        holder.itemView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (mListener != null) {
+                    mListener.onItemClick(conversation);
+                }
+            }
+        });
     }
 
     @Override

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="list" type="id" />
+    <item name="text_view_user_name" type="id" />
+</resources>


### PR DESCRIPTION
This pull request enhances the `ConversationListFragment` by adding click functionality to the conversation items, enabling users to navigate to individual chat conversations.

Changes Made
1. Created `MyConversationRecyclerViewAdapter` class, which extends `RecyclerView.Adapter<MyConversationRecyclerViewAdapter.ViewHolder>`.
2. Implemented an interface `OnItemClickListener` to handle clicks on conversation items within the RecyclerView.
3. Added a method `setOnItemClickListener` to set the click listener for the adapter.
4. Implemented view binding using `FragmentConversationBinding` to access UI elements.
5. Inflated the conversation item layout in the `onCreateViewHolder` method.
6. In the `onBindViewHolder` method:
   - Bound conversation data to the UI elements.
   - Set up a click listener on conversation items to trigger the `OnItemClickListener`.

