### PR TITLE
[Feature 47] adds Settings screen for Account Management

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,11 +13,20 @@
         android:theme="@style/Theme.Tindar"
         tools:targetApi="31">
         <activity
+            android:name=".ui.settings.ChangePasswordActivity"
+            android:exported="false" />
+        <activity
+            android:name=".ui.settings.ChangeEmailActivity"
+            android:exported="false" />
+        <activity
+            android:name=".ui.settings.SettingsActivity"
+            android:exported="false" />
+        <activity
             android:name=".ui.chat.ChatActivity"
             android:exported="false" />
         <activity
             android:name=".ui.signup.SignUpActivity"
-            android:exported="false"/>
+            android:exported="false" />
         <activity
             android:name=".BlankNavActivity"
             android:exported="false"
@@ -33,4 +42,5 @@
             </intent-filter>
         </activity>
     </application>
+
 </manifest>

--- a/app/src/main/java/com/courseproject/tindar/BlankNavActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/BlankNavActivity.java
@@ -21,6 +21,7 @@ import com.courseproject.tindar.databinding.ActivityBlankNavBinding;
 
 public class BlankNavActivity extends AppCompatActivity {
     private AppBarConfiguration mAppBarConfiguration;
+    private String userId;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -28,7 +29,7 @@ public class BlankNavActivity extends AppCompatActivity {
 
         // retrieves user Id passed from other activity
         Intent intent = getIntent();
-        String userId = intent.getStringExtra("user_id");
+        userId = intent.getStringExtra("user_id");
 
         // instantiates the blank nav view model and sets the user id that is currently logged in
         BlankNavViewModel blankNavViewModel = new ViewModelProvider(this).get(BlankNavViewModel.class);
@@ -71,6 +72,7 @@ public class BlankNavActivity extends AppCompatActivity {
             return true;
         } else if (currentItemId == R.id.action_settings) {
             Intent intent = new Intent(BlankNavActivity.this, SettingsActivity.class);
+            intent.putExtra("user_id", userId);
             startActivity(intent);
             return true;
         } else {

--- a/app/src/main/java/com/courseproject/tindar/BlankNavActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/BlankNavActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import com.courseproject.tindar.ui.settings.SettingsActivity;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.navigation.NavigationView;
 
@@ -69,6 +70,8 @@ public class BlankNavActivity extends AppCompatActivity {
             startActivity(intent);
             return true;
         } else if (currentItemId == R.id.action_settings) {
+            Intent intent = new Intent(BlankNavActivity.this, SettingsActivity.class);
+            startActivity(intent);
             return true;
         } else {
             return super.onOptionsItemSelected(item);

--- a/app/src/main/java/com/courseproject/tindar/controllers/editaccount/EditAccountController.java
+++ b/app/src/main/java/com/courseproject/tindar/controllers/editaccount/EditAccountController.java
@@ -63,7 +63,7 @@ public class EditAccountController {
      * @param password the new password to be associated with the account
      */
     public boolean updatePassword(String userId, String password) {
-        if (password.isEmpty()) {
+        if (password.length() < 6) {
             return false;
         }
         else {

--- a/app/src/main/java/com/courseproject/tindar/controllers/editaccount/EditAccountController.java
+++ b/app/src/main/java/com/courseproject/tindar/controllers/editaccount/EditAccountController.java
@@ -49,7 +49,12 @@ public class EditAccountController {
      * @return true if email was successfully updated
      */
     public boolean updateEmail(String userId, String email) {
-        return this.userInput.updateEmail(userId, email);
+        if (email.isEmpty()) {
+            return false;
+        }
+        else {
+            return this.userInput.updateEmail(userId, email);
+        }
     }
 
     /** Change the password associated with an account.

--- a/app/src/main/java/com/courseproject/tindar/ui/settings/ChangeEmailActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/settings/ChangeEmailActivity.java
@@ -15,47 +15,72 @@ import com.courseproject.tindar.usecases.editaccount.EditAccountDsGateway;
 import com.courseproject.tindar.usecases.editaccount.EditAccountInteractor;
 
 public class ChangeEmailActivity extends AppCompatActivity {
-
+    // Button that sends user back to the settings screen.
     ImageButton changeEmailBackButton;
+    // Button that submits changes to the email.
     Button submitEmailChangeButton;
+    // Text box to put in new email.
     EditText changeEmailText;
+    // Text box to put in new email again.
     EditText changeEmailRetype;
+    // Text box to put in the current password for validation.
     EditText changeEmailPasswordValidation;
+    // userId of the account.
     String userId;
 
+    /**
+     * Creates the email change screen for the user to view.
+     *
+     */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_change_email);
 
+        // Retrieves userId from the last screen.
         Intent intent0 = getIntent();
         userId = intent0.getStringExtra("user_id");
 
+        // Creates the controller to use controller methods.
         EditAccountDsGateway editAccountDatabaseHelper = DatabaseHelper.getInstance(getApplicationContext());
         EditAccountInteractor editAccountInteractor = new EditAccountInteractor(editAccountDatabaseHelper);
         EditAccountController editAccountController = new EditAccountController(editAccountInteractor);
 
+        // When the button in the top left is clicked, return user to settings screen.
         changeEmailBackButton = findViewById(R.id.button_back_email_change);
         changeEmailBackButton.setOnClickListener(view -> {
             Intent intent = new Intent(ChangeEmailActivity.this, SettingsActivity.class);
+            // Sends userId to the next screen.
             intent.putExtra("user_id", userId);
             startActivity(intent);
         });
 
+        // Allows for usage of text in textboxes for methods.
         changeEmailText = findViewById(R.id.edit_text_email_change_1);
         changeEmailRetype = findViewById(R.id.edit_text_email_change_2);
         changeEmailPasswordValidation = findViewById(R.id.edit_text_email_password);
 
+        // When the submit change button is pressed,
         submitEmailChangeButton = findViewById(R.id.button_submit_email_change);
         submitEmailChangeButton.setOnClickListener(view -> {
+            // Checks if the email in both fields is the same.
+            // If not, sends a pop-up informing the user the inputs do not match.
             if (changeEmailText.getText().toString().equals(changeEmailRetype.getText().toString())) {
+                // Checks if the password inputted is the current password for the account.
+                // If not, sends a pop-up informing the user the password is incorrect.
                 if (editAccountController.validatePassword(userId, changeEmailPasswordValidation.getText().toString())) {
+                    // Checks if the email is already in use by another account.
+                    // If so, sends a pop-up informing the user the email is already used.
+                    // Will also send that pop-up if email fields are empty.
+                    // Otherwise, changes the email and sends the user back to the home screen.
                     if (editAccountController.updateEmail(userId, changeEmailText.getText().toString())) {
                         // Send back to home screen
                         Intent intent = new Intent(ChangeEmailActivity.this, BlankNavActivity.class);
+                        // Sends userId to the next screen.
                         intent.putExtra("user_id", userId);
                         startActivity(intent);
                     } else {
+                        // This makes the popup window for the email already used alert.
                         LayoutInflater inflater = (LayoutInflater)
                                 getSystemService(LAYOUT_INFLATER_SERVICE);
                         View popupView = inflater.inflate(R.layout.popup_email_already_used, null);
@@ -77,6 +102,7 @@ public class ChangeEmailActivity extends AppCompatActivity {
                         });
                     }
                 } else {
+                    // This makes the popup for the incorrect password.
                     LayoutInflater inflater = (LayoutInflater)
                             getSystemService(LAYOUT_INFLATER_SERVICE);
                     View popupView = inflater.inflate(R.layout.popup_current_password_incorrect, null);
@@ -99,6 +125,7 @@ public class ChangeEmailActivity extends AppCompatActivity {
                 }
             }
             else {
+                // This creates the popup for if the emails do not match.
                 LayoutInflater inflater = (LayoutInflater)
                         getSystemService(LAYOUT_INFLATER_SERVICE);
                 View popupView = inflater.inflate(R.layout.popup_inputs_dont_match, null);

--- a/app/src/main/java/com/courseproject/tindar/ui/settings/ChangeEmailActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/settings/ChangeEmailActivity.java
@@ -1,22 +1,38 @@
 package com.courseproject.tindar.ui.settings;
 
 import android.content.Intent;
-import android.widget.Button;
-import android.widget.ImageButton;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.*;
 import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import com.courseproject.tindar.BlankNavActivity;
 import com.courseproject.tindar.R;
+import com.courseproject.tindar.controllers.editaccount.EditAccountController;
+import com.courseproject.tindar.MainActivity;
+import com.courseproject.tindar.controllers.login.LoginController;
+import com.courseproject.tindar.ds.DatabaseHelper;
+import com.courseproject.tindar.usecases.editaccount.EditAccountDsGateway;
+import com.courseproject.tindar.usecases.editaccount.EditAccountInteractor;
+import com.courseproject.tindar.usecases.login.LoginDsGateway;
+import com.courseproject.tindar.usecases.login.LoginInteractor;
 
 public class ChangeEmailActivity extends AppCompatActivity {
 
     ImageButton changeEmailBackButton;
     Button submitEmailChangeButton;
+    EditText changeEmailText;
+    EditText changeEmailRetype;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_change_email);
+
+        EditAccountDsGateway editAccountDatabaseHelper = DatabaseHelper.getInstance(getApplicationContext());
+        EditAccountInteractor editAccountInteractor = new EditAccountInteractor(editAccountDatabaseHelper);
+        EditAccountController editAccountController = new EditAccountController(editAccountInteractor);
 
         changeEmailBackButton = findViewById(R.id.button_back_email_change);
         changeEmailBackButton.setOnClickListener(view -> {
@@ -24,11 +40,39 @@ public class ChangeEmailActivity extends AppCompatActivity {
             startActivity(intent);
         });
 
+        changeEmailText = findViewById(R.id.edit_text_email_change_1);
+        changeEmailRetype = findViewById(R.id.edit_text_email_change_2);
+
         submitEmailChangeButton = findViewById(R.id.button_submit_email_change);
         submitEmailChangeButton.setOnClickListener(view -> {
+            if (changeEmailText.getText().toString().equals(changeEmailRetype.getText().toString())) {
+                /// editAccountController.updateEmail(, changeEmailText.getText().toString());
 
-            Intent intent = new Intent(ChangeEmailActivity.this, BlankNavActivity.class);
-            startActivity(intent);
+                // Send back to home screen
+                Intent intent = new Intent(ChangeEmailActivity.this, BlankNavActivity.class);
+                startActivity(intent);
+            }
+            else {
+                LayoutInflater inflater = (LayoutInflater)
+                        getSystemService(LAYOUT_INFLATER_SERVICE);
+                View popupView = inflater.inflate(R.layout.popup_inputs_dont_match, null);
+
+                // create the popup window
+                int width = LinearLayout.LayoutParams.WRAP_CONTENT;
+                int height = LinearLayout.LayoutParams.WRAP_CONTENT;
+                boolean focusable = true; // lets taps outside the popup also dismiss it
+                final PopupWindow popupWindow = new PopupWindow(popupView, width, height, focusable);
+
+                // show the popup window
+                // which view you pass in doesn't matter, it is only used for the window token
+                popupWindow.showAtLocation(view, Gravity.CENTER, 0, 0);
+
+                // dismiss the popup window when touched
+                popupView.setOnTouchListener((v, event) -> {
+                    popupWindow.dismiss();
+                    return true;
+                });
+            }
         });
     }
 }

--- a/app/src/main/java/com/courseproject/tindar/ui/settings/ChangeEmailActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/settings/ChangeEmailActivity.java
@@ -10,13 +10,9 @@ import android.os.Bundle;
 import com.courseproject.tindar.BlankNavActivity;
 import com.courseproject.tindar.R;
 import com.courseproject.tindar.controllers.editaccount.EditAccountController;
-import com.courseproject.tindar.MainActivity;
-import com.courseproject.tindar.controllers.login.LoginController;
 import com.courseproject.tindar.ds.DatabaseHelper;
 import com.courseproject.tindar.usecases.editaccount.EditAccountDsGateway;
 import com.courseproject.tindar.usecases.editaccount.EditAccountInteractor;
-import com.courseproject.tindar.usecases.login.LoginDsGateway;
-import com.courseproject.tindar.usecases.login.LoginInteractor;
 
 public class ChangeEmailActivity extends AppCompatActivity {
 

--- a/app/src/main/java/com/courseproject/tindar/ui/settings/ChangeEmailActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/settings/ChangeEmailActivity.java
@@ -1,0 +1,34 @@
+package com.courseproject.tindar.ui.settings;
+
+import android.content.Intent;
+import android.widget.Button;
+import android.widget.ImageButton;
+import androidx.appcompat.app.AppCompatActivity;
+import android.os.Bundle;
+import com.courseproject.tindar.BlankNavActivity;
+import com.courseproject.tindar.R;
+
+public class ChangeEmailActivity extends AppCompatActivity {
+
+    ImageButton changeEmailBackButton;
+    Button submitEmailChangeButton;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_change_email);
+
+        changeEmailBackButton = findViewById(R.id.button_back_email_change);
+        changeEmailBackButton.setOnClickListener(view -> {
+            Intent intent = new Intent(ChangeEmailActivity.this, SettingsActivity.class);
+            startActivity(intent);
+        });
+
+        submitEmailChangeButton = findViewById(R.id.button_submit_email_change);
+        submitEmailChangeButton.setOnClickListener(view -> {
+
+            Intent intent = new Intent(ChangeEmailActivity.this, BlankNavActivity.class);
+            startActivity(intent);
+        });
+    }
+}

--- a/app/src/main/java/com/courseproject/tindar/ui/settings/ChangeEmailActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/settings/ChangeEmailActivity.java
@@ -20,11 +20,16 @@ public class ChangeEmailActivity extends AppCompatActivity {
     Button submitEmailChangeButton;
     EditText changeEmailText;
     EditText changeEmailRetype;
+    EditText changeEmailPasswordValidation;
+    String userId;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_change_email);
+
+        Intent intent0 = getIntent();
+        userId = intent0.getStringExtra("user_id");
 
         EditAccountDsGateway editAccountDatabaseHelper = DatabaseHelper.getInstance(getApplicationContext());
         EditAccountInteractor editAccountInteractor = new EditAccountInteractor(editAccountDatabaseHelper);
@@ -33,20 +38,65 @@ public class ChangeEmailActivity extends AppCompatActivity {
         changeEmailBackButton = findViewById(R.id.button_back_email_change);
         changeEmailBackButton.setOnClickListener(view -> {
             Intent intent = new Intent(ChangeEmailActivity.this, SettingsActivity.class);
+            intent.putExtra("user_id", userId);
             startActivity(intent);
         });
 
         changeEmailText = findViewById(R.id.edit_text_email_change_1);
         changeEmailRetype = findViewById(R.id.edit_text_email_change_2);
+        changeEmailPasswordValidation = findViewById(R.id.edit_text_email_password);
 
         submitEmailChangeButton = findViewById(R.id.button_submit_email_change);
         submitEmailChangeButton.setOnClickListener(view -> {
             if (changeEmailText.getText().toString().equals(changeEmailRetype.getText().toString())) {
-                /// editAccountController.updateEmail(, changeEmailText.getText().toString());
+                if (editAccountController.validatePassword(userId, changeEmailPasswordValidation.getText().toString())) {
+                    if (editAccountController.updateEmail(userId, changeEmailText.getText().toString())) {
+                        // Send back to home screen
+                        Intent intent = new Intent(ChangeEmailActivity.this, BlankNavActivity.class);
+                        intent.putExtra("user_id", userId);
+                        startActivity(intent);
+                    } else {
+                        LayoutInflater inflater = (LayoutInflater)
+                                getSystemService(LAYOUT_INFLATER_SERVICE);
+                        View popupView = inflater.inflate(R.layout.popup_email_already_used, null);
 
-                // Send back to home screen
-                Intent intent = new Intent(ChangeEmailActivity.this, BlankNavActivity.class);
-                startActivity(intent);
+                        // create the popup window
+                        int width = LinearLayout.LayoutParams.WRAP_CONTENT;
+                        int height = LinearLayout.LayoutParams.WRAP_CONTENT;
+                        boolean focusable = true; // lets taps outside the popup also dismiss it
+                        final PopupWindow popupWindow = new PopupWindow(popupView, width, height, focusable);
+
+                        // show the popup window
+                        // which view you pass in doesn't matter, it is only used for the window token
+                        popupWindow.showAtLocation(view, Gravity.CENTER, 0, 0);
+
+                        // dismiss the popup window when touched
+                        popupView.setOnTouchListener((v, event) -> {
+                            popupWindow.dismiss();
+                            return true;
+                        });
+                    }
+                } else {
+                    LayoutInflater inflater = (LayoutInflater)
+                            getSystemService(LAYOUT_INFLATER_SERVICE);
+                    View popupView = inflater.inflate(R.layout.popup_current_password_incorrect, null);
+
+                    // create the popup window
+                    int width = LinearLayout.LayoutParams.WRAP_CONTENT;
+                    int height = LinearLayout.LayoutParams.WRAP_CONTENT;
+                    boolean focusable = true; // lets taps outside the popup also dismiss it
+                    final PopupWindow popupWindow = new PopupWindow(popupView, width, height, focusable);
+
+                    // show the popup window
+                    // which view you pass in doesn't matter, it is only used for the window token
+                    popupWindow.showAtLocation(view, Gravity.CENTER, 0, 0);
+
+                    // dismiss the popup window when touched
+                    popupView.setOnTouchListener((v, event) -> {
+                        popupWindow.dismiss();
+                        return true;
+                    });
+                }
             }
             else {
                 LayoutInflater inflater = (LayoutInflater)

--- a/app/src/main/java/com/courseproject/tindar/ui/settings/ChangePasswordActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/settings/ChangePasswordActivity.java
@@ -1,0 +1,34 @@
+package com.courseproject.tindar.ui.settings;
+
+import android.content.Intent;
+import android.widget.Button;
+import android.widget.ImageButton;
+import androidx.appcompat.app.AppCompatActivity;
+import android.os.Bundle;
+import com.courseproject.tindar.BlankNavActivity;
+import com.courseproject.tindar.R;
+
+public class ChangePasswordActivity extends AppCompatActivity {
+    ImageButton changePasswordBackButton;
+    Button submitPasswordChangeButton;
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_change_password);
+
+        changePasswordBackButton = findViewById(R.id.button_back_password_change);
+        changePasswordBackButton.setOnClickListener(view -> {
+            Intent intent = new Intent(ChangePasswordActivity.this, SettingsActivity.class);
+            startActivity(intent);
+        });
+
+        submitPasswordChangeButton = findViewById(R.id.button_submit_password_change);
+        submitPasswordChangeButton.setOnClickListener(view -> {
+
+            Intent intent = new Intent(ChangePasswordActivity.this, BlankNavActivity.class);
+            startActivity(intent);
+        });
+    }
+}

--- a/app/src/main/java/com/courseproject/tindar/ui/settings/ChangePasswordActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/settings/ChangePasswordActivity.java
@@ -15,48 +15,94 @@ import com.courseproject.tindar.usecases.editaccount.EditAccountDsGateway;
 import com.courseproject.tindar.usecases.editaccount.EditAccountInteractor;
 
 public class ChangePasswordActivity extends AppCompatActivity {
+    // Button that sends the user back to the settings screen.
     ImageButton changePasswordBackButton;
+    // Button that submits the changes to the password.
     Button submitPasswordChangeButton;
+    // Text box that contains the new password.
     EditText changePasswordText;
+    // Text box to type the new password a second time.
     EditText changePasswordRetype;
+    // Text box to type the current password for validation.
     EditText changePasswordValidation;
+    // The user id of the account.
     String userId;
 
-
+    /**
+     * Creates the password change screen for the user to view.
+     *
+     */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_change_password);
 
+        // Retrieves the user id from the previous screen.
         Intent intent0 = getIntent();
         userId = intent0.getStringExtra("user_id");
 
-
+        // Creates the controller to use methods to change account details.
         EditAccountDsGateway editAccountDatabaseHelper = DatabaseHelper.getInstance(getApplicationContext());
         EditAccountInteractor editAccountInteractor = new EditAccountInteractor(editAccountDatabaseHelper);
         EditAccountController editAccountController = new EditAccountController(editAccountInteractor);
 
+        // When the button in the top left is pressed, sends the user back to the settings screen.
         changePasswordBackButton = findViewById(R.id.button_back_password_change);
         changePasswordBackButton.setOnClickListener(view -> {
             Intent intent = new Intent(ChangePasswordActivity.this, SettingsActivity.class);
-
+            // Sends the user id to the next screen.
+            intent.putExtra("user_id", userId);
             startActivity(intent);
         });
 
+        // Allows for the usage of text in text boxes to be used.
         changePasswordText = findViewById(R.id.edit_text_password_change);
         changePasswordRetype = findViewById(R.id.edit_text_password_retyped_change);
         changePasswordValidation = findViewById(R.id.edit_text_password_password);
 
+        // When the button to submit password changes is pressed,
         submitPasswordChangeButton = findViewById(R.id.button_submit_password_change);
         submitPasswordChangeButton.setOnClickListener(view -> {
+            // Checks if both new passwords are the same.
+            // If not, sends a pop-up saying inputs do not match.
             if (changePasswordText.getText().toString().equals(changePasswordRetype.getText().toString())) {
+                // Checks if the current password is correct.
+                // If not, sends a message saying password is incorrect.
                 if (editAccountController.validatePassword(userId, changePasswordValidation.getText().toString())) {
-                    editAccountController.updatePassword(userId, changePasswordText.getText().toString());
+                    // Checks if the new password is less than 6 characters long.
+                    // If so, sends a message saying new password not long enough.
+                    if (editAccountController.updatePassword(userId, changePasswordText.getText().toString())) {
+                        // Sends the user back to the home screen.
+                        Intent intent = new Intent(ChangePasswordActivity.this, BlankNavActivity.class);
+                        // Sends the user id to the next screen.
+                        intent.putExtra("user_id", userId);
+                        startActivity(intent);
+                    }
+                    else {
+                        // Creates popup window to say passwords don't match.
+                        LayoutInflater inflater = (LayoutInflater)
+                                getSystemService(LAYOUT_INFLATER_SERVICE);
+                        View popupView = inflater.inflate(R.layout.popup_password_not_long, null);
 
-                    Intent intent = new Intent(ChangePasswordActivity.this, BlankNavActivity.class);
-                    intent.putExtra("user_id", userId);
-                    startActivity(intent);
-                } else {
+                        // create the popup window
+                        int width = LinearLayout.LayoutParams.WRAP_CONTENT;
+                        int height = LinearLayout.LayoutParams.WRAP_CONTENT;
+                        boolean focusable = true; // lets taps outside the popup also dismiss it
+                        final PopupWindow popupWindow = new PopupWindow(popupView, width, height, focusable);
+
+                        // show the popup window
+                        // which view you pass in doesn't matter, it is only used for the window token
+                        popupWindow.showAtLocation(view, Gravity.CENTER, 0, 0);
+
+                        // dismiss the popup window when touched
+                        popupView.setOnTouchListener((v, event) -> {
+                            popupWindow.dismiss();
+                            return true;
+                        });
+                    }
+                }
+                else {
+                    // Creates pop window to say the current password is incorrect.
                     LayoutInflater inflater = (LayoutInflater)
                             getSystemService(LAYOUT_INFLATER_SERVICE);
                     View popupView = inflater.inflate(R.layout.popup_current_password_incorrect, null);
@@ -77,7 +123,9 @@ public class ChangePasswordActivity extends AppCompatActivity {
                         return true;
                     });
                 }
-            } else {
+            }
+            else {
+                // Creates the popup window to say passwords do not match.
                 LayoutInflater inflater = (LayoutInflater)
                         getSystemService(LAYOUT_INFLATER_SERVICE);
                 View popupView = inflater.inflate(R.layout.popup_inputs_dont_match, null);

--- a/app/src/main/java/com/courseproject/tindar/ui/settings/ChangePasswordActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/settings/ChangePasswordActivity.java
@@ -1,8 +1,10 @@
 package com.courseproject.tindar.ui.settings;
 
 import android.content.Intent;
-import android.widget.Button;
-import android.widget.ImageButton;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.*;
 import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import com.courseproject.tindar.BlankNavActivity;
@@ -11,6 +13,8 @@ import com.courseproject.tindar.R;
 public class ChangePasswordActivity extends AppCompatActivity {
     ImageButton changePasswordBackButton;
     Button submitPasswordChangeButton;
+    EditText changePasswordText;
+    EditText changePasswordRetype;
 
 
     @Override
@@ -24,11 +28,37 @@ public class ChangePasswordActivity extends AppCompatActivity {
             startActivity(intent);
         });
 
+        changePasswordText = findViewById(R.id.edit_text_password_change);
+        changePasswordRetype = findViewById(R.id.edit_text_password_retyped_change);
+
         submitPasswordChangeButton = findViewById(R.id.button_submit_password_change);
         submitPasswordChangeButton.setOnClickListener(view -> {
+            if (changePasswordText.getText().toString().equals(changePasswordRetype.getText().toString())) {
 
-            Intent intent = new Intent(ChangePasswordActivity.this, BlankNavActivity.class);
-            startActivity(intent);
+                Intent intent = new Intent(ChangePasswordActivity.this, BlankNavActivity.class);
+                startActivity(intent);
+            }
+            else {
+                LayoutInflater inflater = (LayoutInflater)
+                        getSystemService(LAYOUT_INFLATER_SERVICE);
+                View popupView = inflater.inflate(R.layout.popup_inputs_dont_match, null);
+
+                // create the popup window
+                int width = LinearLayout.LayoutParams.WRAP_CONTENT;
+                int height = LinearLayout.LayoutParams.WRAP_CONTENT;
+                boolean focusable = true; // lets taps outside the popup also dismiss it
+                final PopupWindow popupWindow = new PopupWindow(popupView, width, height, focusable);
+
+                // show the popup window
+                // which view you pass in doesn't matter, it is only used for the window token
+                popupWindow.showAtLocation(view, Gravity.CENTER, 0, 0);
+
+                // dismiss the popup window when touched
+                popupView.setOnTouchListener((v, event) -> {
+                    popupWindow.dismiss();
+                    return true;
+                });
+            }
         });
     }
 }

--- a/app/src/main/java/com/courseproject/tindar/ui/settings/ChangePasswordActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/settings/ChangePasswordActivity.java
@@ -9,12 +9,18 @@ import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import com.courseproject.tindar.BlankNavActivity;
 import com.courseproject.tindar.R;
+import com.courseproject.tindar.controllers.editaccount.EditAccountController;
+import com.courseproject.tindar.ds.DatabaseHelper;
+import com.courseproject.tindar.usecases.editaccount.EditAccountDsGateway;
+import com.courseproject.tindar.usecases.editaccount.EditAccountInteractor;
 
 public class ChangePasswordActivity extends AppCompatActivity {
     ImageButton changePasswordBackButton;
     Button submitPasswordChangeButton;
     EditText changePasswordText;
     EditText changePasswordRetype;
+    EditText changePasswordValidation;
+    String userId;
 
 
     @Override
@@ -22,23 +28,56 @@ public class ChangePasswordActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_change_password);
 
+        Intent intent0 = getIntent();
+        userId = intent0.getStringExtra("user_id");
+
+
+        EditAccountDsGateway editAccountDatabaseHelper = DatabaseHelper.getInstance(getApplicationContext());
+        EditAccountInteractor editAccountInteractor = new EditAccountInteractor(editAccountDatabaseHelper);
+        EditAccountController editAccountController = new EditAccountController(editAccountInteractor);
+
         changePasswordBackButton = findViewById(R.id.button_back_password_change);
         changePasswordBackButton.setOnClickListener(view -> {
             Intent intent = new Intent(ChangePasswordActivity.this, SettingsActivity.class);
+
             startActivity(intent);
         });
 
         changePasswordText = findViewById(R.id.edit_text_password_change);
         changePasswordRetype = findViewById(R.id.edit_text_password_retyped_change);
+        changePasswordValidation = findViewById(R.id.edit_text_password_password);
 
         submitPasswordChangeButton = findViewById(R.id.button_submit_password_change);
         submitPasswordChangeButton.setOnClickListener(view -> {
             if (changePasswordText.getText().toString().equals(changePasswordRetype.getText().toString())) {
+                if (editAccountController.validatePassword(userId, changePasswordValidation.getText().toString())) {
+                    editAccountController.updatePassword(userId, changePasswordText.getText().toString());
 
-                Intent intent = new Intent(ChangePasswordActivity.this, BlankNavActivity.class);
-                startActivity(intent);
-            }
-            else {
+                    Intent intent = new Intent(ChangePasswordActivity.this, BlankNavActivity.class);
+                    intent.putExtra("user_id", userId);
+                    startActivity(intent);
+                } else {
+                    LayoutInflater inflater = (LayoutInflater)
+                            getSystemService(LAYOUT_INFLATER_SERVICE);
+                    View popupView = inflater.inflate(R.layout.popup_current_password_incorrect, null);
+
+                    // create the popup window
+                    int width = LinearLayout.LayoutParams.WRAP_CONTENT;
+                    int height = LinearLayout.LayoutParams.WRAP_CONTENT;
+                    boolean focusable = true; // lets taps outside the popup also dismiss it
+                    final PopupWindow popupWindow = new PopupWindow(popupView, width, height, focusable);
+
+                    // show the popup window
+                    // which view you pass in doesn't matter, it is only used for the window token
+                    popupWindow.showAtLocation(view, Gravity.CENTER, 0, 0);
+
+                    // dismiss the popup window when touched
+                    popupView.setOnTouchListener((v, event) -> {
+                        popupWindow.dismiss();
+                        return true;
+                    });
+                }
+            } else {
                 LayoutInflater inflater = (LayoutInflater)
                         getSystemService(LAYOUT_INFLATER_SERVICE);
                 View popupView = inflater.inflate(R.layout.popup_inputs_dont_match, null);

--- a/app/src/main/java/com/courseproject/tindar/ui/settings/SettingsActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/settings/SettingsActivity.java
@@ -1,0 +1,36 @@
+package com.courseproject.tindar.ui.settings;
+
+import android.content.Intent;
+import android.provider.Settings;
+import android.widget.Button;
+import android.widget.ImageButton;
+import androidx.appcompat.app.AppCompatActivity;
+import android.os.Bundle;
+import com.courseproject.tindar.BlankNavActivity;
+import com.courseproject.tindar.R;
+
+public class SettingsActivity extends AppCompatActivity {
+
+    Button changeEmailButton;
+    Button changePasswordButton;
+    ImageButton settingsBackButton;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_settings);
+
+        changeEmailButton = findViewById(R.id.button_email_change);
+        changePasswordButton = findViewById(R.id.button_password_change);
+
+        changeEmailButton.setOnClickListener(view -> {
+            Intent intent = new Intent(SettingsActivity.this, ChangeEmailActivity.class);
+            startActivity(intent);});
+
+        settingsBackButton = findViewById(R.id.button_back_settings_change);
+        settingsBackButton.setOnClickListener(view -> {
+            Intent intent = new Intent(SettingsActivity.this, BlankNavActivity.class);
+            startActivity(intent);
+        });
+    }
+}

--- a/app/src/main/java/com/courseproject/tindar/ui/settings/SettingsActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/settings/SettingsActivity.java
@@ -1,7 +1,6 @@
 package com.courseproject.tindar.ui.settings;
 
 import android.content.Intent;
-import android.provider.Settings;
 import android.widget.Button;
 import android.widget.ImageButton;
 import androidx.appcompat.app.AppCompatActivity;
@@ -25,6 +24,10 @@ public class SettingsActivity extends AppCompatActivity {
 
         changeEmailButton.setOnClickListener(view -> {
             Intent intent = new Intent(SettingsActivity.this, ChangeEmailActivity.class);
+            startActivity(intent);});
+
+        changePasswordButton.setOnClickListener(view -> {
+            Intent intent = new Intent(SettingsActivity.this, ChangePasswordActivity.class);
             startActivity(intent);});
 
         settingsBackButton = findViewById(R.id.button_back_settings_change);

--- a/app/src/main/java/com/courseproject/tindar/ui/settings/SettingsActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/settings/SettingsActivity.java
@@ -9,36 +9,51 @@ import com.courseproject.tindar.BlankNavActivity;
 import com.courseproject.tindar.R;
 
 public class SettingsActivity extends AppCompatActivity {
-
+    // Button that sends user to change email screen.
     Button changeEmailButton;
+    // Button that sends user to change password screen.
     Button changePasswordButton;
+    // Button that sends user back to the home screen.
     ImageButton settingsBackButton;
+    // userId of the account.
     String userId;
 
+    /**
+     * Creates the settings screen for the user to view.
+     *
+     */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_settings);
 
+        // pulls userId from the Intent sent by BlankNavActivity and sets userId to hold that info.
         Intent intent0 = getIntent();
         userId = intent0.getStringExtra("user_id");
 
+        // Allows us to use the two buttons.
         changeEmailButton = findViewById(R.id.button_email_change);
         changePasswordButton = findViewById(R.id.button_password_change);
 
+        // When the "Change Email" button is clicked, sends the user to ChangeEmailActivity
         changeEmailButton.setOnClickListener(view -> {
             Intent intent = new Intent(SettingsActivity.this, ChangeEmailActivity.class);
+            // Sends the userId to the next screen.
             intent.putExtra("user_id", userId);
             startActivity(intent);});
 
+        // When the "Change Password" button is clicked, sends the user to ChangePasswordActivity
         changePasswordButton.setOnClickListener(view -> {
             Intent intent = new Intent(SettingsActivity.this, ChangePasswordActivity.class);
+            // Sends the userId to the next screen.
             intent.putExtra("user_id", userId);
             startActivity(intent);});
 
+        // When the back button in the top left is clicked, sends the user back to BlankNavActivity
         settingsBackButton = findViewById(R.id.button_back_settings_change);
         settingsBackButton.setOnClickListener(view -> {
             Intent intent = new Intent(SettingsActivity.this, BlankNavActivity.class);
+            // Sends the userId to the next screen.
             intent.putExtra("user_id", userId);
             startActivity(intent);
         });

--- a/app/src/main/java/com/courseproject/tindar/ui/settings/SettingsActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/settings/SettingsActivity.java
@@ -13,26 +13,33 @@ public class SettingsActivity extends AppCompatActivity {
     Button changeEmailButton;
     Button changePasswordButton;
     ImageButton settingsBackButton;
+    String userId;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_settings);
 
+        Intent intent0 = getIntent();
+        userId = intent0.getStringExtra("user_id");
+
         changeEmailButton = findViewById(R.id.button_email_change);
         changePasswordButton = findViewById(R.id.button_password_change);
 
         changeEmailButton.setOnClickListener(view -> {
             Intent intent = new Intent(SettingsActivity.this, ChangeEmailActivity.class);
+            intent.putExtra("user_id", userId);
             startActivity(intent);});
 
         changePasswordButton.setOnClickListener(view -> {
             Intent intent = new Intent(SettingsActivity.this, ChangePasswordActivity.class);
+            intent.putExtra("user_id", userId);
             startActivity(intent);});
 
         settingsBackButton = findViewById(R.id.button_back_settings_change);
         settingsBackButton.setOnClickListener(view -> {
             Intent intent = new Intent(SettingsActivity.this, BlankNavActivity.class);
+            intent.putExtra("user_id", userId);
             startActivity(intent);
         });
     }

--- a/app/src/main/res/layout/activity_change_email.xml
+++ b/app/src/main/res/layout/activity_change_email.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".ui.settings.ChangeEmailActivity">
+
+
+    <ImageButton
+        android:id="@+id/button_back_email_change"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="0dp"
+        android:layout_marginTop="0dp"
+        android:backgroundTint="@color/colorPrimary"
+        app:srcCompat="@drawable/baseline_arrow_back_32_white" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/app_name"
+        android:textAlignment="center"
+        android:textSize="50sp"
+        android:layout_marginStart="25dp"
+        android:layout_marginBottom="5dp"
+        android:layout_marginTop="60dp"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/filler"
+        android:textSize="17sp"
+        android:layout_marginStart="25dp"
+        android:layout_marginBottom="50dp"/>
+
+    <EditText
+        android:id="@+id/edit_text_email_change"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:hint="@string/prompt_email"
+        android:layout_marginLeft="20dp"
+        android:layout_marginRight="20dp"
+        android:layout_marginBottom="10dp"
+        android:padding="15dp"
+        android:inputType="textEmailAddress"
+        android:textSize="15sp" />
+
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <Button
+            android:id="@+id/button_submit_email_change"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:layout_marginLeft="20dp"
+            android:layout_marginRight="20dp"
+            android:layout_marginBottom="30dp"
+            android:text="@string/submit_email"
+            android:textColor="@android:color/white" />
+
+    </RelativeLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_change_email.xml
+++ b/app/src/main/res/layout/activity_change_email.xml
@@ -42,6 +42,18 @@
         android:inputType="textEmailAddress"
         android:textSize="15sp" />
 
+    <EditText
+        android:id="@+id/edit_text_email_password"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:hint="@string/password_validation"
+        android:layout_marginLeft="20dp"
+        android:layout_marginRight="20dp"
+        android:layout_marginBottom="10dp"
+        android:padding="15dp"
+        android:inputType="textPassword"
+        android:textSize="15sp" />
+
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_change_email.xml
+++ b/app/src/main/res/layout/activity_change_email.xml
@@ -18,29 +18,23 @@
         android:backgroundTint="@color/colorPrimary"
         app:srcCompat="@drawable/baseline_arrow_back_32_white" />
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/app_name"
-        android:textAlignment="center"
-        android:textSize="50sp"
-        android:layout_marginStart="25dp"
-        android:layout_marginBottom="5dp"
-        android:layout_marginTop="60dp"/>
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/filler"
-        android:textSize="17sp"
-        android:layout_marginStart="25dp"
-        android:layout_marginBottom="50dp"/>
-
     <EditText
-        android:id="@+id/edit_text_email_change"
+        android:id="@+id/edit_text_email_change_1"
         android:layout_width="match_parent"
         android:layout_height="50dp"
-        android:hint="@string/prompt_email"
+        android:hint="@string/new_email"
+        android:layout_marginLeft="20dp"
+        android:layout_marginRight="20dp"
+        android:layout_marginBottom="10dp"
+        android:padding="15dp"
+        android:inputType="textEmailAddress"
+        android:textSize="15sp" />
+
+    <EditText
+        android:id="@+id/edit_text_email_change_2"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:hint="@string/retype_email"
         android:layout_marginLeft="20dp"
         android:layout_marginRight="20dp"
         android:layout_marginBottom="10dp"

--- a/app/src/main/res/layout/activity_change_password.xml
+++ b/app/src/main/res/layout/activity_change_password.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".ui.settings.ChangePasswordActivity">
+
+
+    <ImageButton
+        android:id="@+id/button_back_password_change"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="0dp"
+        android:layout_marginTop="0dp"
+        android:backgroundTint="@color/colorPrimary"
+        app:srcCompat="@drawable/baseline_arrow_back_32_white" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/app_name"
+        android:textAlignment="center"
+        android:textSize="50sp"
+        android:layout_marginStart="25dp"
+        android:layout_marginBottom="5dp"
+        android:layout_marginTop="60dp"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/filler"
+        android:textSize="17sp"
+        android:layout_marginStart="25dp"
+        android:layout_marginBottom="50dp"/>
+
+    <EditText
+        android:id="@+id/edit_text_password_change"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:hint="@string/prompt_password"
+        android:layout_marginLeft="20dp"
+        android:layout_marginRight="20dp"
+        android:layout_marginBottom="10dp"
+        android:padding="15dp"
+        android:inputType="textPassword"
+        android:textSize="15sp" />
+
+    <EditText
+        android:id="@+id/edit_text_password_retyped_change"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:hint="@string/re_type_password"
+        android:layout_marginLeft="20dp"
+        android:layout_marginRight="20dp"
+        android:padding="15dp"
+        android:inputType="textPassword"
+        android:textSize="15sp" />
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <Button
+            android:id="@+id/button_submit_password_change"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:layout_marginLeft="20dp"
+            android:layout_marginRight="20dp"
+            android:layout_marginBottom="30dp"
+            android:text="@string/submit_password"
+            android:textColor="@android:color/white" />
+
+    </RelativeLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_change_password.xml
+++ b/app/src/main/res/layout/activity_change_password.xml
@@ -18,34 +18,16 @@
         android:backgroundTint="@color/colorPrimary"
         app:srcCompat="@drawable/baseline_arrow_back_32_white" />
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/app_name"
-        android:textAlignment="center"
-        android:textSize="50sp"
-        android:layout_marginStart="25dp"
-        android:layout_marginBottom="5dp"
-        android:layout_marginTop="60dp"/>
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/filler"
-        android:textSize="17sp"
-        android:layout_marginStart="25dp"
-        android:layout_marginBottom="50dp"/>
-
     <EditText
         android:id="@+id/edit_text_password_change"
         android:layout_width="match_parent"
-        android:layout_height="50dp"
-        android:hint="@string/prompt_password"
+        android:layout_height="wrap_content"
         android:layout_marginLeft="20dp"
         android:layout_marginRight="20dp"
         android:layout_marginBottom="10dp"
-        android:padding="15dp"
+        android:hint="@string/new_password"
         android:inputType="textPassword"
+        android:padding="15dp"
         android:textSize="15sp" />
 
     <EditText
@@ -58,6 +40,7 @@
         android:padding="15dp"
         android:inputType="textPassword"
         android:textSize="15sp" />
+
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_change_password.xml
+++ b/app/src/main/res/layout/activity_change_password.xml
@@ -41,6 +41,18 @@
         android:inputType="textPassword"
         android:textSize="15sp" />
 
+    <EditText
+        android:id="@+id/edit_text_password_password"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:hint="@string/password_validation"
+        android:layout_marginLeft="20dp"
+        android:layout_marginRight="20dp"
+        android:layout_marginBottom="10dp"
+        android:padding="15dp"
+        android:inputType="textPassword"
+        android:textSize="15sp" />
+
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.settings.SettingsActivity">
+
+    <ImageButton
+        android:id="@+id/button_back_settings_change"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:backgroundTint="@color/colorPrimary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/baseline_arrow_back_32_white" />
+
+    <Button
+        android:id="@+id/button_email_change"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/change_email"
+        app:layout_constraintBottom_toTopOf="@id/button_password_change"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.821" />
+
+    <Button
+        android:id="@+id/button_password_change"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="220dp"
+        android:text="@string/change_password"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/popup_current_password_incorrect.xml
+++ b/app/src/main/res/layout/popup_current_password_incorrect.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+             android:layout_height="match_parent">
+
+
+    <TextView
+        android:id="@+id/popup_password_incorrect"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/current_password_incorrect"
+        android:textColor="#FF0000"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.084" />
+</RelativeLayout>

--- a/app/src/main/res/layout/popup_email_already_used.xml
+++ b/app/src/main/res/layout/popup_email_already_used.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+             android:layout_height="match_parent">
+
+
+    <TextView
+        android:id="@+id/email_already_used"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/email_already_used"
+        android:textColor="#FF0000"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.084" />
+</RelativeLayout>

--- a/app/src/main/res/layout/popup_inputs_dont_match.xml
+++ b/app/src/main/res/layout/popup_inputs_dont_match.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+             android:layout_height="match_parent">
+
+
+    <TextView
+        android:id="@+id/popup_inputs_wrong"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/inputs_do_not_match"
+        android:textColor="#FF0000"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.084" />
+</RelativeLayout>

--- a/app/src/main/res/layout/popup_password_not_long.xml
+++ b/app/src/main/res/layout/popup_password_not_long.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+             android:layout_height="match_parent">
+
+
+    <TextView
+        android:id="@+id/popup_password_not_long"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/password_not_six_long"
+        android:textColor="#FF0000"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.084" />
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,4 +73,7 @@
     <string name="new_password">New Password</string>
     <string name="current_password_2">Current Password</string>
     <string name="inputs_do_not_match">Inputs do not match</string>
+    <string name="email_already_used">Email already used</string>
+    <string name="current_password_incorrect">Current password incorrect</string>
+    <string name="password_validation">Current password</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,4 +63,8 @@
     <string name="my_profile">My Profile</string>
 
     <string name="action_log_out">Log Out</string>
+    <string name="change_email">Change Email</string>
+    <string name="change_password">Change Password</string>
+    <string name="submit_email">Submit Email</string>
+    <string name="submit_password">Submit Password</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,4 +76,5 @@
     <string name="email_already_used">Email already used</string>
     <string name="current_password_incorrect">Current password incorrect</string>
     <string name="password_validation">Current password</string>
+    <string name="password_not_six_long">Passwords must be at least 6 characters long.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,4 +67,10 @@
     <string name="change_password">Change Password</string>
     <string name="submit_email">Submit Email</string>
     <string name="submit_password">Submit Password</string>
+    <string name="retype_email">Retype Email</string>
+    <string name="new_email">New Email</string>
+    <string name="current_password">Current Password</string>
+    <string name="new_password">New Password</string>
+    <string name="current_password_2">Current Password</string>
+    <string name="inputs_do_not_match">Inputs do not match</string>
 </resources>


### PR DESCRIPTION
In the PR, I created front-end settings screens for Account Management, and connected it to the back-end for Account Management. I also created Javadocs and comments for the code.

I created 3 new Activity classes in the ui.settings package:
- SettingsActivity, which is the main settings screen, which can send a user to either the email or password change screens.
- ChangeEmailActivity, which is the screen used to change emails. Asks for a user to input a new email twice, and their current password.
- ChangePasswordActivity, which is the screen used to change passwords. Asks for a user to input a new password twice, and their current password.

All the Activity screens also come with a back button in the top left corner, in order to return to a previous screen.

I also created 7 new layout .xml files:
- activity_change_email, which has the layout for ChangeEmailActivity.
- activity_change_password, which has the layout for ChangePasswordActivity.
- activity_settings, which has the layout for SettingsActivity.
- popup_current_password_incorrect, which has the layout for a popup that appears when the current password is incorrect in ChangeEmailActivity and ChangePasswordActivity.
- popup_email_already_used, which has the layout for a popup that appears when the new email inputted is already used by another account.
- popup_inputs_dont_match, which has the layout for a popup that appears when the two new emails or two new passwords are not the same.
- popup_password_not_long, which has the layout for a popup that appears when the new password is not at least 6 characters long.

I made changes to EditAccountController to check whether a password is at least 6 characters long.
I made changes to BlankNavActivity to pass userId to Settings activity.

* Closes #47