### PR TITLE
[Feature 90] adds functionality to edit display name on the Edit Profile screen

### DIFF
--- a/app/src/androidTest/java/com/courseproject/tindar/ds/DatabaseHelperTest.java
+++ b/app/src/androidTest/java/com/courseproject/tindar/ds/DatabaseHelperTest.java
@@ -98,11 +98,12 @@ public class DatabaseHelperTest {
     @Test
     public void testUpdateProfile() {
         EditProfileRequestModel newProfile = new EditProfileRequestModel(
-                new GregorianCalendar(1997, 11, 27).getTime(),
+                "fido", new GregorianCalendar(1997, 11, 27).getTime(),
                 "Other", "Vancouver", "https://bbb", "Nice to meet you"
         );
         dbHelper.updateProfile(userId, newProfile);
         ViewProfileResponseModel updatedProfile = dbHelper.readProfile(userId);
+        assertEquals("fido", updatedProfile.getDisplayName());
         assertEquals(new GregorianCalendar(1997, 11, 27).getTime(), updatedProfile.getBirthdate());
         assertEquals("Other", updatedProfile.getGender());
         assertEquals("Vancouver", updatedProfile.getLocation());

--- a/app/src/main/java/com/courseproject/tindar/ds/DatabaseHelper.java
+++ b/app/src/main/java/com/courseproject/tindar/ds/DatabaseHelper.java
@@ -536,8 +536,8 @@ public class DatabaseHelper extends SQLiteOpenHelper implements EditProfileDsGat
         return true;
     }
 
-    /** Retrieves profile information of a user from the database. It includes birthdate, gender, location,
-     * profile picture link, and about me statement of the user.
+    /** Retrieves profile information of a user from the database. It includes display name, birthdate, gender,
+     * location, profile picture link, and about me statement of the user.
      *
      * @param userId the user id of the account
      * @return profile information of the user
@@ -571,8 +571,8 @@ public class DatabaseHelper extends SQLiteOpenHelper implements EditProfileDsGat
         return dsResponse;
     }
 
-    /** updates the profile information of a user in the database. It includes birthdate, gender, location,
-     * profile picture link, and about me statement of the user.
+    /** updates the profile information of a user in the database. It includes display name, birthdate, gender,
+     * location, profile picture link, and about me statement of the user.
      *
      * @param userId the user id of the account
      * @param newProfile new profile information of the user
@@ -581,6 +581,7 @@ public class DatabaseHelper extends SQLiteOpenHelper implements EditProfileDsGat
     public void updateProfile(String userId, EditProfileRequestModel newProfile) {
         SQLiteDatabase db = this.getWritableDatabase();
         ContentValues cv = new ContentValues();
+        cv.put(DISPLAY_NAME, newProfile.getDisplayName());
         cv.put(BIRTHDATE, new java.sql.Date(newProfile.getBirthdate().getTime()).getTime());
         cv.put(GENDER, newProfile.getGender());
         cv.put(LOCATION, newProfile.getLocation());

--- a/app/src/main/java/com/courseproject/tindar/ui/editprofile/EditProfileFragment.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/editprofile/EditProfileFragment.java
@@ -2,6 +2,7 @@ package com.courseproject.tindar.ui.editprofile;
 
 import android.app.DatePickerDialog;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -46,6 +47,10 @@ public class EditProfileFragment extends Fragment {
      * the user id of the current logged-in user
      */
     private String userId;
+    /**
+     * the edit text to input display name
+     */
+    private EditText displayNameEditText;
     /**
      * the text view to show user's birthdate
      */
@@ -129,6 +134,7 @@ public class EditProfileFragment extends Fragment {
         View root = binding.getRoot();
 
         // finds components and assigns each to a variable
+        displayNameEditText = root.findViewById(R.id.edit_text_display_name);
         birthdateTextView = root.findViewById(R.id.text_view_birthday);
         genderAutoCompleteTextView = root.findViewById(R.id.auto_complete_text_view_gender);
         locationAutoCompleteTextView = root.findViewById(R.id.auto_complete_text_view_location);
@@ -159,8 +165,10 @@ public class EditProfileFragment extends Fragment {
         profileSubmitButton.setOnClickListener(view -> {
             try {
                 EditProfileRequestModel newProfile = getProfileInputValues();
-                editProfileController.updateProfile(userId, newProfile);
-                setEditEnabled(false);
+                if (newProfile != null) {
+                    editProfileController.updateProfile(userId, newProfile);
+                    setEditEnabled(false);
+                }
             } catch (ParseException e) {
                 birthdateTextView.setText(DateFormat.getDateInstance().format(profileDsResponse.getBirthdate()));
             }
@@ -205,6 +213,7 @@ public class EditProfileFragment extends Fragment {
         profileDsResponse = editProfileController.getProfile(userId);
 
         // renders user profile to the screen
+        displayNameEditText.setText(profileDsResponse.getDisplayName());
         birthdateTextView.setText(DateFormat.getDateInstance().format(profileDsResponse.getBirthdate()));
         genderAutoCompleteTextView.setText(profileDsResponse.getGender());
         locationAutoCompleteTextView.setText(profileDsResponse.getLocation());
@@ -226,7 +235,14 @@ public class EditProfileFragment extends Fragment {
      * @return profile input values.
      */
     private EditProfileRequestModel getProfileInputValues()  throws ParseException {
+        // shows error message if user tries to submit without display name
+        if (TextUtils.isEmpty(displayNameEditText.getText().toString())) {
+            displayNameEditText.setError("Please enter name.");
+            return null;
+        }
+
         return new EditProfileRequestModel(
+            displayNameEditText.getText().toString(),
             DateFormat.getDateInstance(DateFormat.DEFAULT).parse(birthdateTextView.getText().toString()),
             genderAutoCompleteTextView.getText().toString(),
             locationAutoCompleteTextView.getText().toString(),
@@ -244,6 +260,7 @@ public class EditProfileFragment extends Fragment {
     private void setEditEnabled(boolean enabled) {
         profileEditButton.setVisibility(enabled ? View.INVISIBLE : View.VISIBLE);
         profileSubmitButton.setEnabled(enabled);
+        displayNameEditText.setEnabled(enabled);
         birthdateTextView.setEnabled(enabled);
         genderAutoCompleteTextView.setEnabled(enabled);
         locationAutoCompleteTextView.setEnabled(enabled);

--- a/app/src/main/java/com/courseproject/tindar/usecases/editprofile/EditProfileRequestModel.java
+++ b/app/src/main/java/com/courseproject/tindar/usecases/editprofile/EditProfileRequestModel.java
@@ -8,6 +8,11 @@ import lombok.Getter;
  * data model for the profile on the update request
  */
 public class EditProfileRequestModel {
+
+    /**
+     * display name of the user
+     */
+    @Getter private final String displayName;
     /**
      * birthdate of the user
      */
@@ -30,13 +35,20 @@ public class EditProfileRequestModel {
     @Getter private final String aboutMe;
 
     /**
+     * Constructs Edit Profile Model for fetching and updating profile
+     *
+     * @param displayName display name of the user
      * @param birthdate birthdate of the user
      * @param gender gender of the user
      * @param location location where the user lives in
      * @param profilePictureLink link to the profile picture of the user
      * @param aboutMe statement the user writes to introduce him/herself to other users
      */
-    public EditProfileRequestModel(Date birthdate, String gender, String location, String profilePictureLink, String aboutMe) {
+
+    public EditProfileRequestModel(String displayName, Date birthdate, String gender, String location,
+                                   String profilePictureLink,
+                                   String aboutMe) {
+        this.displayName = displayName;
         this.birthdate = birthdate;
         this.gender = gender;
         this.location = location;

--- a/app/src/main/java/com/courseproject/tindar/usecases/viewprofile/ViewProfileResponseModel.java
+++ b/app/src/main/java/com/courseproject/tindar/usecases/viewprofile/ViewProfileResponseModel.java
@@ -5,7 +5,7 @@ import java.util.Date;
 import lombok.Getter;
 
 /**
- * data model for the profile on the fetch request
+ * data model for the profile on the fetch/update request
  */
 public class ViewProfileResponseModel {
 

--- a/app/src/main/res/layout/fragment_edit_profile.xml
+++ b/app/src/main/res/layout/fragment_edit_profile.xml
@@ -216,6 +216,7 @@
                 android:id="@+id/edit_text_about_me"
                 android:layout_width="match_parent"
                 android:layout_height="150dp"
+                android:gravity="start"
                 android:enabled="false"
                 android:inputType="none"
                 android:importantForAutofill="no" />

--- a/app/src/main/res/layout/fragment_edit_profile.xml
+++ b/app/src/main/res/layout/fragment_edit_profile.xml
@@ -37,14 +37,47 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="50dp"
+            android:layout_height="wrap_content"
             android:layout_marginStart="10dp"
             android:layout_marginEnd="10dp"
             android:orientation="horizontal">
 
             <TextView
                 android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:gravity="center"
+                android:labelFor="@id/edit_text_display_name"
+                android:text="@string/name" />
+
+        </LinearLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginEnd="10dp">
+
+            <EditText
+                android:id="@+id/edit_text_display_name"
+                android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:enabled="false"
+                android:inputType="none"
+                android:importantForAutofill="no" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginEnd="10dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:gravity="center"
                 android:labelFor="@id/text_view_birthday"
@@ -61,14 +94,14 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="50dp"
+            android:layout_height="wrap_content"
             android:layout_marginStart="10dp"
             android:layout_marginEnd="10dp"
             android:orientation="horizontal">
 
             <TextView
                 android:layout_width="wrap_content"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:gravity="center"
                 android:text="@string/gender"
@@ -93,14 +126,14 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="50dp"
+            android:layout_height="wrap_content"
             android:layout_marginStart="10dp"
             android:layout_marginEnd="10dp"
             android:orientation="horizontal">
 
             <TextView
                 android:layout_width="wrap_content"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:gravity="center"
                 android:text="@string/location"
@@ -125,14 +158,14 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="50dp"
+            android:layout_height="wrap_content"
             android:layout_marginStart="10dp"
             android:layout_marginEnd="10dp"
             android:orientation="horizontal">
 
             <TextView
                 android:layout_width="wrap_content"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:gravity="center"
                 android:text="@string/profile_picture_link"
@@ -158,14 +191,14 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="50dp"
+            android:layout_height="wrap_content"
             android:layout_marginStart="10dp"
             android:layout_marginEnd="10dp"
             android:orientation="horizontal">
 
             <TextView
                 android:layout_width="wrap_content"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:gravity="center"
                 android:text="@string/about_me"
@@ -182,7 +215,7 @@
             <EditText
                 android:id="@+id/edit_text_about_me"
                 android:layout_width="match_parent"
-                android:layout_height="350dp"
+                android:layout_height="150dp"
                 android:enabled="false"
                 android:inputType="none"
                 android:importantForAutofill="no" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="re_type_password">Re-type Password</string>
 
     <!-- Strings related to other screens -->
+    <string name="name">Name</string>
     <string name="birthdate">Birthdate</string>
     <string name="gender">Gender</string>
     <string name="location">Location</string>

--- a/app/src/test/java/com/courseproject/tindar/controllers/editprofile/EditProfileControllerUnitTest.java
+++ b/app/src/test/java/com/courseproject/tindar/controllers/editprofile/EditProfileControllerUnitTest.java
@@ -2,8 +2,8 @@ package com.courseproject.tindar.controllers.editprofile;
 
 import static org.junit.Assert.assertEquals;
 
-import com.courseproject.tindar.usecases.editprofile.EditProfileRequestModel;
 import com.courseproject.tindar.usecases.editprofile.EditProfileInputBoundary;
+import com.courseproject.tindar.usecases.editprofile.EditProfileRequestModel;
 import com.courseproject.tindar.usecases.viewprofile.ViewProfileInputBoundary;
 import com.courseproject.tindar.usecases.viewprofile.ViewProfileResponseModel;
 
@@ -28,6 +28,7 @@ public class EditProfileControllerUnitTest {
         @Override
         public void updateProfile(String userId, EditProfileRequestModel newProfile) {
             assertEquals(USER_ID, userId);
+            assertEquals(DISPLAY_NAME, newProfile.getDisplayName());
             assertEquals(BIRTHDATE, newProfile.getBirthdate());
             assertEquals(GENDER, newProfile.getGender());
             assertEquals(LOCATION, newProfile.getLocation());
@@ -61,7 +62,7 @@ public class EditProfileControllerUnitTest {
     @Test
     public void testUpdateProfile() {
         EditProfileController testEditProfileController = new EditProfileController(mockEditProfileUserInput, mockViewProfileUserInput);
-        EditProfileRequestModel newProfile = new EditProfileRequestModel(BIRTHDATE, GENDER, LOCATION,
+        EditProfileRequestModel newProfile = new EditProfileRequestModel(DISPLAY_NAME, BIRTHDATE, GENDER, LOCATION,
                 PROFILE_PICTURE_LINK, ABOUT_ME);
         testEditProfileController.updateProfile(USER_ID, newProfile);
     }

--- a/app/src/test/java/com/courseproject/tindar/usecases/editprofile/EditProfileInteractorUnitTest.java
+++ b/app/src/test/java/com/courseproject/tindar/usecases/editprofile/EditProfileInteractorUnitTest.java
@@ -9,6 +9,7 @@ import java.util.GregorianCalendar;
 
 public class EditProfileInteractorUnitTest {
     private static final String USER_ID = "99";
+    private static final String DISPLAY_NAME = "fido";
     private static final Date BIRTHDATE = new GregorianCalendar(1999, 3, 10).getTime();
     private static final String GENDER = "Male";
     private static final String LOCATION = "Toronto";
@@ -20,6 +21,7 @@ public class EditProfileInteractorUnitTest {
         @Override
         public void updateProfile(String userId, EditProfileRequestModel newProfile) {
             assertEquals(USER_ID, userId);
+            assertEquals(DISPLAY_NAME, newProfile.getDisplayName());
             assertEquals(BIRTHDATE, newProfile.getBirthdate());
             assertEquals(GENDER, newProfile.getGender());
             assertEquals(LOCATION, newProfile.getLocation());
@@ -33,7 +35,7 @@ public class EditProfileInteractorUnitTest {
     @Test
     public void testUpdateProfile() {
         EditProfileInteractor testEditProfileInteractor = new EditProfileInteractor(mockEditProfileDsGateway);
-        EditProfileRequestModel newProfile = new EditProfileRequestModel(BIRTHDATE, GENDER, LOCATION,
+        EditProfileRequestModel newProfile = new EditProfileRequestModel(DISPLAY_NAME, BIRTHDATE, GENDER, LOCATION,
                 PROFILE_PICTURE_LINK, ABOUT_ME);
         testEditProfileInteractor.updateProfile(USER_ID, newProfile);
     }


### PR DESCRIPTION
What:
adds functionality to edit the display name of the user in the Edit Profile screen

Why:
a user wants to edit his/her display name somewhere in the app

Implementation Details
Adds EditText to input display name. It throws an error if a user tries to submit the updated profile information without the display name inputted. Implementation for updating the display name is the same as other fields in the profile update. I just needed to add one extra attribute in the EditProfileRequestModel

Closes #90