### PR TITLE
[Bug 8] fixes error message when email is not entered in the change email feature

### DIFF
--- a/app/src/main/java/com/courseproject/tindar/controllers/editaccount/EditAccountController.java
+++ b/app/src/main/java/com/courseproject/tindar/controllers/editaccount/EditAccountController.java
@@ -49,12 +49,7 @@ public class EditAccountController {
      * @return true if email was successfully updated
      */
     public boolean updateEmail(String userId, String email) {
-        if (email.isEmpty()) {
-            return false;
-        }
-        else {
-            return this.userInput.updateEmail(userId, email);
-        }
+        return this.userInput.updateEmail(userId, email);
     }
 
     /** Change the password associated with an account.
@@ -63,11 +58,6 @@ public class EditAccountController {
      * @param password the new password to be associated with the account
      */
     public boolean updatePassword(String userId, String password) {
-        if (password.length() < 6) {
-            return false;
-        }
-        else {
-            return this.userInput.updatePassword(userId, password);
-        }
+        return this.userInput.updatePassword(userId, password);
     }
 }

--- a/app/src/main/java/com/courseproject/tindar/ui/settings/ChangeEmailActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/settings/ChangeEmailActivity.java
@@ -1,8 +1,8 @@
 package com.courseproject.tindar.ui.settings;
 
 import android.content.Intent;
+import android.text.TextUtils;
 import android.view.Gravity;
-import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.*;
 import androidx.appcompat.app.AppCompatActivity;
@@ -63,6 +63,11 @@ public class ChangeEmailActivity extends AppCompatActivity {
         // When the submit change button is pressed,
         submitEmailChangeButton = findViewById(R.id.button_submit_email_change);
         submitEmailChangeButton.setOnClickListener(view -> {
+            if (TextUtils.isEmpty(changeEmailText.getText().toString())) {
+                changeEmailText.setError("Please enter email.");
+                return;
+            }
+
             // Checks if the email in both fields is the same.
             // If not, sends a pop-up informing the user the inputs do not match.
             if (changeEmailText.getText().toString().equals(changeEmailRetype.getText().toString())) {
@@ -81,9 +86,7 @@ public class ChangeEmailActivity extends AppCompatActivity {
                         startActivity(intent);
                     } else {
                         // This makes the popup window for the email already used alert.
-                        LayoutInflater inflater = (LayoutInflater)
-                                getSystemService(LAYOUT_INFLATER_SERVICE);
-                        View popupView = inflater.inflate(R.layout.popup_email_already_used, null);
+                        View popupView = View.inflate(ChangeEmailActivity.this, R.layout.popup_email_already_used, null);
 
                         // create the popup window
                         int width = LinearLayout.LayoutParams.WRAP_CONTENT;
@@ -98,14 +101,13 @@ public class ChangeEmailActivity extends AppCompatActivity {
                         // dismiss the popup window when touched
                         popupView.setOnTouchListener((v, event) -> {
                             popupWindow.dismiss();
+                            v.performClick();
                             return true;
                         });
                     }
                 } else {
                     // This makes the popup for the incorrect password.
-                    LayoutInflater inflater = (LayoutInflater)
-                            getSystemService(LAYOUT_INFLATER_SERVICE);
-                    View popupView = inflater.inflate(R.layout.popup_current_password_incorrect, null);
+                    View popupView = View.inflate(ChangeEmailActivity.this, R.layout.popup_current_password_incorrect, null);
 
                     // create the popup window
                     int width = LinearLayout.LayoutParams.WRAP_CONTENT;
@@ -119,6 +121,7 @@ public class ChangeEmailActivity extends AppCompatActivity {
 
                     // dismiss the popup window when touched
                     popupView.setOnTouchListener((v, event) -> {
+                        v.performClick();
                         popupWindow.dismiss();
                         return true;
                     });
@@ -126,9 +129,7 @@ public class ChangeEmailActivity extends AppCompatActivity {
             }
             else {
                 // This creates the popup for if the emails do not match.
-                LayoutInflater inflater = (LayoutInflater)
-                        getSystemService(LAYOUT_INFLATER_SERVICE);
-                View popupView = inflater.inflate(R.layout.popup_inputs_dont_match, null);
+                View popupView = View.inflate(ChangeEmailActivity.this, R.layout.popup_inputs_dont_match, null);
 
                 // create the popup window
                 int width = LinearLayout.LayoutParams.WRAP_CONTENT;
@@ -142,6 +143,7 @@ public class ChangeEmailActivity extends AppCompatActivity {
 
                 // dismiss the popup window when touched
                 popupView.setOnTouchListener((v, event) -> {
+                    v.performClick();
                     popupWindow.dismiss();
                     return true;
                 });

--- a/app/src/main/java/com/courseproject/tindar/ui/settings/ChangePasswordActivity.java
+++ b/app/src/main/java/com/courseproject/tindar/ui/settings/ChangePasswordActivity.java
@@ -1,8 +1,8 @@
 package com.courseproject.tindar.ui.settings;
 
 import android.content.Intent;
+import android.text.TextUtils;
 import android.view.Gravity;
-import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.*;
 import androidx.appcompat.app.AppCompatActivity;
@@ -63,6 +63,11 @@ public class ChangePasswordActivity extends AppCompatActivity {
         // When the button to submit password changes is pressed,
         submitPasswordChangeButton = findViewById(R.id.button_submit_password_change);
         submitPasswordChangeButton.setOnClickListener(view -> {
+            if (TextUtils.isEmpty(changePasswordText.getText().toString())) {
+                changePasswordText.setError("Please enter password.");
+                return;
+            }
+
             // Checks if both new passwords are the same.
             // If not, sends a pop-up saying inputs do not match.
             if (changePasswordText.getText().toString().equals(changePasswordRetype.getText().toString())) {
@@ -79,10 +84,8 @@ public class ChangePasswordActivity extends AppCompatActivity {
                         startActivity(intent);
                     }
                     else {
-                        // Creates popup window to say passwords don't match.
-                        LayoutInflater inflater = (LayoutInflater)
-                                getSystemService(LAYOUT_INFLATER_SERVICE);
-                        View popupView = inflater.inflate(R.layout.popup_password_not_long, null);
+                        // Creates popup window to say passwords is not long enough
+                        View popupView = View.inflate(ChangePasswordActivity.this, R.layout.popup_password_not_long, null);
 
                         // create the popup window
                         int width = LinearLayout.LayoutParams.WRAP_CONTENT;
@@ -96,6 +99,7 @@ public class ChangePasswordActivity extends AppCompatActivity {
 
                         // dismiss the popup window when touched
                         popupView.setOnTouchListener((v, event) -> {
+                            v.performClick();
                             popupWindow.dismiss();
                             return true;
                         });
@@ -103,9 +107,7 @@ public class ChangePasswordActivity extends AppCompatActivity {
                 }
                 else {
                     // Creates pop window to say the current password is incorrect.
-                    LayoutInflater inflater = (LayoutInflater)
-                            getSystemService(LAYOUT_INFLATER_SERVICE);
-                    View popupView = inflater.inflate(R.layout.popup_current_password_incorrect, null);
+                    View popupView = View.inflate(ChangePasswordActivity.this, R.layout.popup_current_password_incorrect, null);
 
                     // create the popup window
                     int width = LinearLayout.LayoutParams.WRAP_CONTENT;
@@ -119,6 +121,7 @@ public class ChangePasswordActivity extends AppCompatActivity {
 
                     // dismiss the popup window when touched
                     popupView.setOnTouchListener((v, event) -> {
+                        v.performClick();
                         popupWindow.dismiss();
                         return true;
                     });
@@ -126,9 +129,7 @@ public class ChangePasswordActivity extends AppCompatActivity {
             }
             else {
                 // Creates the popup window to say passwords do not match.
-                LayoutInflater inflater = (LayoutInflater)
-                        getSystemService(LAYOUT_INFLATER_SERVICE);
-                View popupView = inflater.inflate(R.layout.popup_inputs_dont_match, null);
+                View popupView = View.inflate(ChangePasswordActivity.this, R.layout.popup_inputs_dont_match, null);
 
                 // create the popup window
                 int width = LinearLayout.LayoutParams.WRAP_CONTENT;
@@ -142,6 +143,7 @@ public class ChangePasswordActivity extends AppCompatActivity {
 
                 // dismiss the popup window when touched
                 popupView.setOnTouchListener((v, event) -> {
+                    v.performClick();
                     popupWindow.dismiss();
                     return true;
                 });

--- a/app/src/main/java/com/courseproject/tindar/usecases/editaccount/EditAccountInteractor.java
+++ b/app/src/main/java/com/courseproject/tindar/usecases/editaccount/EditAccountInteractor.java
@@ -20,6 +20,9 @@ public class EditAccountInteractor implements EditAccountInputBoundary {
     }
 
     public boolean updatePassword(String userId, String password) {
+        if (password.length() < 6) {
+            return false;
+        }
         return this.editAccountDsGateway.updatePassword(userId, password);
     }
 }

--- a/app/src/test/java/com/courseproject/tindar/controllers/editaccount/EditAccountControllerUnitTest.java
+++ b/app/src/test/java/com/courseproject/tindar/controllers/editaccount/EditAccountControllerUnitTest.java
@@ -2,7 +2,6 @@ package com.courseproject.tindar.controllers.editaccount;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 
 import com.courseproject.tindar.usecases.editaccount.EditAccountDsResponseModel;
 import com.courseproject.tindar.usecases.editaccount.EditAccountInputBoundary;
@@ -67,7 +66,7 @@ public class EditAccountControllerUnitTest {
     final EditAccountInputBoundary mockEditAccountUserInput = new MockEditAccountUserInput();
 
     @Test
-    public void getAccount() {
+    public void testGetAccount() {
         EditAccountController testEditAccountController = new EditAccountController(mockEditAccountUserInput);
         EditAccountDsResponseModel testEditAccountDsResponseModel = testEditAccountController.getAccount(USER_ID);
         assertEquals(IS_ACTIVE_STATUS, testEditAccountDsResponseModel.getIsActiveStatus());
@@ -76,33 +75,26 @@ public class EditAccountControllerUnitTest {
     }
 
     @Test
-    public void validatePassword() {
+    public void testValidatePassword() {
         EditAccountController testEditAccountController = new EditAccountController(mockEditAccountUserInput);
         assertTrue(testEditAccountController.validatePassword(USER_ID, PASSWORD));
     }
 
     @Test
-    public void updateIsActiveStatus() {
+    public void testUpdateIsActiveStatus() {
         EditAccountController testEditAccountController = new EditAccountController(mockEditAccountUserInput);
         testEditAccountController.updateIsActiveStatus(USER_ID, IS_ACTIVE_STATUS);
     }
 
     @Test
-    public void updateEmail() {
+    public void testUpdateEmail() {
         EditAccountController testEditAccountController = new EditAccountController(mockEditAccountUserInput);
         assertTrue(testEditAccountController.updateEmail(USER_ID, EMAIL));
     }
 
     @Test
-    public void updatePassword() {
+    public void testUpdatePassword() {
         EditAccountController testEditAccountController = new EditAccountController(mockEditAccountUserInput);
         assertTrue(testEditAccountController.updatePassword(USER_ID, PASSWORD));
     }
-
-    @Test
-    public void updatePasswordEmpty() {
-        EditAccountController testEditAccountController = new EditAccountController(mockEditAccountUserInput);
-        assertFalse(testEditAccountController.updatePassword(USER_ID, ""));
-    }
-
 }

--- a/app/src/test/java/com/courseproject/tindar/usecases/editaccount/EditAccountInteractorUnitTest.java
+++ b/app/src/test/java/com/courseproject/tindar/usecases/editaccount/EditAccountInteractorUnitTest.java
@@ -63,7 +63,7 @@ public class EditAccountInteractorUnitTest {
     final EditAccountDsGateway mockEditAccountDsGateway = new MockEditAccountDsGateway();
 
     @Test
-    public void getAccount() {
+    public void testGetAccount() {
         EditAccountInteractor testEditAccountInteractor = new EditAccountInteractor(mockEditAccountDsGateway);
         EditAccountDsResponseModel testEditAccountDsResponseModel = testEditAccountInteractor.getAccount(USER_ID);
         assertEquals(IS_ACTIVE_STATUS, testEditAccountDsResponseModel.getIsActiveStatus());
@@ -72,29 +72,26 @@ public class EditAccountInteractorUnitTest {
     }
 
     @Test
-    public void updateIsActiveStatus() {
+    public void testUpdateIsActiveStatus() {
         EditAccountInteractor testEditAccountInteractor = new EditAccountInteractor(mockEditAccountDsGateway);
         testEditAccountInteractor.updateIsActiveStatus(USER_ID, IS_ACTIVE_STATUS);
     }
 
     @Test
-    public void updateEmail() {
+    public void testUpdateEmail() {
         EditAccountInteractor testEditAccountInteractor = new EditAccountInteractor(mockEditAccountDsGateway);
         assertTrue(testEditAccountInteractor.updateEmail(USER_ID, EMAIL));
     }
 
     @Test
-    public void updatePassword() {
+    public void testUpdatePassword() {
         EditAccountInteractor testEditAccountInteractor = new EditAccountInteractor(mockEditAccountDsGateway);
         assertTrue(testEditAccountInteractor.updatePassword(USER_ID, PASSWORD));
     }
 
     @Test
-    public void updatePasswordEmpty() {
+    public void testUpdatePasswordTooShort() {
         EditAccountInteractor testEditAccountInteractor = new EditAccountInteractor(mockEditAccountDsGateway);
-        assertFalse(testEditAccountInteractor.updatePassword(USER_ID, ""));
+        assertFalse(testEditAccountInteractor.updatePassword(USER_ID, "short"));
     }
-
-
-
 }


### PR DESCRIPTION
What:
fix the error message in the change email feature when there is no email input when the user submits. Before, It was saying email is already in use.

Why:
want to provide the correct reason to the user for the error so the user can fix it accordingly

Implementation Details:
- Now when there is no input email when the user submits in the change email feature or there is no password when the user submits in the change password feature, it shows a little error icon on the right in the input field with the correct error message. 
- moves password-too-short logic from controller to interactor
- Edit Account Controller test coverage is now 100%
- fixes some warnings in the change email activity and change password activity

This closes https://github.com/CSC207-2023Y-UofT/course-project-tindar/issues/137