### PR TITLE
[Task 36] updates database version and onUpgrade method in the DatabaseHelper class

### DIFF
--- a/app/src/main/java/com/courseproject/tindar/ds/DatabaseHelper.java
+++ b/app/src/main/java/com/courseproject/tindar/ds/DatabaseHelper.java
@@ -54,6 +54,10 @@ public class DatabaseHelper extends SQLiteOpenHelper implements EditProfileDsGat
      */
     private static DatabaseHelper testDbInstance;
     /**
+     * current database version
+     */
+    private static final int databaseVersion = 2;
+    /**
      * table name for the accounts
      */
     private static final String TABLE_ACCOUNTS = "accounts";
@@ -254,7 +258,7 @@ public class DatabaseHelper extends SQLiteOpenHelper implements EditProfileDsGat
     private DatabaseHelper(@Nullable Context context, String databaseName) {
         // access modifier is private so DatabaseHelper doesn't get directly instantiated. The instantiation of
         // DatabaseHelper should go through getInstance method.
-        super(context, databaseName, null, 1);
+        super(context, databaseName, null, databaseVersion);
     }
 
     /**
@@ -283,12 +287,14 @@ public class DatabaseHelper extends SQLiteOpenHelper implements EditProfileDsGat
      */
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        db.execSQL("DROP TABLE IF EXISTS " + TABLE_ACCOUNTS);
-        db.execSQL("DROP TABLE IF EXISTS " + TABLE_LIKES);
-        db.execSQL("DROP TABLE IF EXISTS " + TABLE_MATCHES);
-        db.execSQL("DROP TABLE IF EXISTS " + TABLE_MESSAGES);
-        db.execSQL("DROP TABLE IF EXISTS " + TABLE_CONVERSATIONS);
-        onCreate(db);
+        if (oldVersion < newVersion) {
+            db.execSQL("DROP TABLE IF EXISTS " + TABLE_ACCOUNTS);
+            db.execSQL("DROP TABLE IF EXISTS " + TABLE_LIKES);
+            db.execSQL("DROP TABLE IF EXISTS " + TABLE_MATCHES);
+            db.execSQL("DROP TABLE IF EXISTS " + TABLE_MESSAGES);
+            db.execSQL("DROP TABLE IF EXISTS " + TABLE_CONVERSATIONS);
+            onCreate(db);
+        }
     }
 
     /**


### PR DESCRIPTION
What:
Update the database version to 2 and update onUpgrade method in the DatabaseHelper class

Why:
The database has changed since the last submission, and if someone has an old database created in the device, we want to have a smooth upgrade on the database without crashing the app.

Implementation Details:
Update database version to 2 from 1
Inside onUpgrade method make an if statement such that if newVersion > oldVersion, then drop all the tables and calls onCreate method again.

closes https://github.com/CSC207-2023Y-UofT/course-project-tindar/issues/164