### PR TITLE
[Task 38] delete already addressed todo comment in the DatabaseHelperTest 

### DIFF
--- a/app/src/androidTest/java/com/courseproject/tindar/ds/DatabaseHelperTest.java
+++ b/app/src/androidTest/java/com/courseproject/tindar/ds/DatabaseHelperTest.java
@@ -66,13 +66,8 @@ public class DatabaseHelperTest {
         dbHelper.close();
     }
 
-    // TODO: addAccount is indirectly tested in the Read methods. addAccount to be fully tested once there is
-    //  DatabaseHelper method which reads the remaining columns of accounts table other than what ReadProfile method
-    //  reads and returns
-
     @Test
     public void testAddAccount() {
-        //TODO: get readAccount to check if the value inserted is right
         SignUpDsRequestModel accountCredentials = new SignUpDsRequestModel("april", "april@someemail.com",
                 "aprilpassword");
         String createdUserId = dbHelper.addAccount(accountCredentials);


### PR DESCRIPTION
What:
Deletes already addressed TODO comment in the DatabaseHelperTest

Why:
To keep the codebase clean, and not confuse some other contributors to the codebase

Implementation Details:
N/A